### PR TITLE
Provide a way to serve the syndicated tool from an alternative host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-_site/
+/_site/
+/.bundle/

--- a/widgets.html
+++ b/widgets.html
@@ -60,6 +60,14 @@
                     <label for="tool_width">Tool width:</label>
                     <input type="text" id="tool_width" value="" />
                 </div>
+                <div>
+                    <label for="tool_host_url">Tool host:</label>
+                    <input type="text" id="tool_host_url" value="{{site.public_website_url}}" />
+                    <p>Use "Tool host" to serve the tool itself from an
+                      alternative host, for example from the QA server. Note
+                      this does not override the host that the
+                      <code>syndication/tools.js</code> script is loaded from.</p>
+                </div>
             </section>
             <div>
                 <input type="submit" id="update" value="Update" />
@@ -123,9 +131,16 @@
 
         $('.settings').on('submit', function(e) {
             var selectedToolId = $(this).find('#tool_id').val(),
-                toolWidth = $('.settings .tool #tool_width').val();
+                toolWidth = $('.settings .tool #tool_width').val(),
+                toolHostUrl = $('.settings .tool #tool_host_url').val();
 
             e.preventDefault();
+
+            if ((toolHostUrl !== '') &&
+                (toolHostUrl !== '{{site.public_website_url}}')) {
+                window.toolsConfig = window.toolsConfig || {};
+                window.toolsConfig['syndication_url'] = toolHostUrl;
+            }
 
             update();
 


### PR DESCRIPTION
# NOTE if you review this please don't merge yet, I'm considering an alternative solution.

Provides a new form field in `widgets.html` that lets you specify an alternative host to fetch the syndicated tool from.

UI looks as follows:

---

![screen shot 2014-12-16 at 17 34 53](https://cloud.githubusercontent.com/assets/306583/5458425/0eabe21c-854a-11e4-98c7-cdb2925a5702.png)

---
